### PR TITLE
chore: add permalink for docs so folder is create

### DIFF
--- a/docs.md
+++ b/docs.md
@@ -1,6 +1,7 @@
 ---
 layout: page
 title: Axe API Documentation
+permalink: /docs/
 ---
 
 


### PR DESCRIPTION
Fixes #2 by using a permalink. This makes Jekyll generate a `docs/index.html` for the file, instead of `docs.html` at the root.